### PR TITLE
select product for purchase-order

### DIFF
--- a/routes/dlg-porder-new.js
+++ b/routes/dlg-porder-new.js
@@ -150,6 +150,7 @@ function doDlgPOrderNew(porderid)
     doDlgProductSelect
     (
       supplierid,
+      '',
       true,
       true,
       function(productid, productname, qty, price)
@@ -158,7 +159,7 @@ function doDlgPOrderNew(porderid)
         (
           'appendRow',
           {
-            id: productid,
+            // id: productid,
             productid: productid,
             qty: qty,
             price: price


### PR DESCRIPTION
fix the bug: click the 'Add' button, no product is added to the datagrid. 
Reason: appendRow, have extra fields. 